### PR TITLE
Navbar fixedtop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,10 @@ gem 'jbuilder', '~> 2.7'
 gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-gem 'money-rails'
-gem 'stripe'
-gem 'stripe_event'
-gem 'sidekiq'
+gem 'money-rails', '~> 1.13.3'
+gem 'stripe', '~> 5.28.0'
+gem 'stripe_event', '~> 2.3.1'
+gem 'sidekiq', '~> 6.1.2'
 gem 'sidekiq-failures', '~> 1.0'
 
 # Use Active Storage variant
@@ -33,22 +33,22 @@ gem 'sidekiq-failures', '~> 1.0'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'mail_form', '~> 1.5', '>= 1.5.1'
-gem 'devise'
-gem 'autoprefixer-rails'
-gem 'font-awesome-sass'
-gem 'simple_form'
-gem 'geocoder'
+gem 'devise', '~> 4.7.3'
+gem 'autoprefixer-rails', '~> 10.0.1.0'
+gem 'font-awesome-sass', '~> 5.13.0'
+gem 'simple_form', '~> 5.0.3'
+gem 'geocoder', '~> 1.6.4'
 
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'dotenv-rails'
-  gem 'rspec-rails'
-  gem 'factory_bot_rails'
-  gem 'faker'
-  gem 'rails-controller-testing'
-  gem 'shoulda-matchers'
-  gem 'webmock'
+  gem 'dotenv-rails', '~> 2.7.6'
+  gem 'rspec-rails', '~> 4.0.1'
+  gem 'factory_bot_rails', '~> 6.1.0'
+  gem 'faker', '~> 2.14.0'
+  gem 'rails-controller-testing', '~> 1.0.5'
+  gem 'shoulda-matchers', '~> 4.4.1'
+  gem 'webmock', '~> 3.9.2'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -66,9 +66,9 @@ end
 group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '~> 3.142.7'
   # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
+  gem 'webdrivers', '~> 4.4.1'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,18 +195,18 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.2.2)
-    regexp_parser (1.8.1)
+    regexp_parser (1.8.2)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rspec-core (3.9.3)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
+      rspec-support (~> 3.10.0)
     rspec-rails (4.0.1)
       actionpack (>= 4.2)
       activesupport (>= 4.2)
@@ -215,7 +215,7 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
-    rspec-support (3.9.3)
+    rspec-support (3.10.0)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -262,7 +262,7 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -288,49 +288,49 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.4.0)
+    zeitwerk (2.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  autoprefixer-rails
+  autoprefixer-rails (~> 10.0.1.0)
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
-  devise
-  dotenv-rails
-  factory_bot_rails
-  faker
-  font-awesome-sass
-  geocoder
+  devise (~> 4.7.3)
+  dotenv-rails (~> 2.7.6)
+  factory_bot_rails (~> 6.1.0)
+  faker (~> 2.14.0)
+  font-awesome-sass (~> 5.13.0)
+  geocoder (~> 1.6.4)
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mail_form (~> 1.5, >= 1.5.1)
-  money-rails
+  money-rails (~> 1.13.3)
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.3)
-  rails-controller-testing
+  rails-controller-testing (~> 1.0.5)
   redis (~> 4.0)
-  rspec-rails
+  rspec-rails (~> 4.0.1)
   sass-rails (>= 6)
-  selenium-webdriver
-  shoulda-matchers
-  sidekiq
+  selenium-webdriver (~> 3.142.7)
+  shoulda-matchers (~> 4.4.1)
+  sidekiq (~> 6.1.2)
   sidekiq-failures (~> 1.0)
-  simple_form
+  simple_form (~> 5.0.3)
   spring
   spring-watcher-listen (~> 2.0.0)
-  stripe
-  stripe_event
+  stripe (~> 5.28.0)
+  stripe_event (~> 2.3.1)
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
-  webdrivers
-  webmock
+  webdrivers (~> 4.4.1)
+  webmock (~> 3.9.2)
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -23,3 +23,6 @@ $border-radius-lg: 2px;
 $border-radius-sm: 2px;
 
 // Override other variables below!
+body{
+  padding-top: 56px;
+}

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -214,5 +214,17 @@ body{
   .font-size-footer{
     font-size:10px;
   }
+  .container-hotel{
+    .hotel-home {
+      .photos-hotel{
+        .photo-buddha{
+          width: 100%;
+        }
+      }
+    }
+  }
+  .restaurant-text, .image-size-home{
+    width: 100%;
+  }
 }
 


### PR DESCRIPTION
- Résolution de deux derniers petits bug sur la home page
- "Protection" des gems en ajoutant une version à ne pas dépasser (Sans ça, elle peuvent se mettre automatiquement à jour et risquer de casser certaines features)
- Ajout d'un padding sur le body top pour "contrer" l'effet fixed-top de la navbar qui est devant le contenu